### PR TITLE
修复设备空间不足拷贝会奔溃的情况

### DIFF
--- a/android/src/main/kotlin/top/kikt/imagescanner/core/cache/AndroidQCache.kt
+++ b/android/src/main/kotlin/top/kikt/imagescanner/core/cache/AndroidQCache.kt
@@ -10,6 +10,7 @@ import top.kikt.imagescanner.core.utils.AndroidQDBUtils
 import top.kikt.imagescanner.util.LogUtils
 import java.io.File
 import java.io.FileOutputStream
+import java.lang.Exception
 
 /// create 2019-09-10 by cai
 
@@ -40,13 +41,15 @@ class AndroidQCache {
     if (uri == Uri.EMPTY){
       return null
     }
-    if (isOrigin) {
-      uri = MediaStore.setRequireOriginal(uri)
-    }
-    val inputStream = contentResolver.openInputStream(uri)
-    val outputStream = FileOutputStream(targetFile)
-    outputStream.use {
-      inputStream?.copyTo(it)
+    try {
+      val inputStream = contentResolver.openInputStream(uri)
+      val outputStream = FileOutputStream(targetFile)
+      outputStream.use {
+        inputStream?.copyTo(it)
+      }
+    }catch (e:Exception){
+      LogUtils.info("$assetId , isOrigin: $isOrigin, copy file error:${e.localizedMessage}")
+      return null
     }
     return targetFile
   }


### PR DESCRIPTION
1、修复设备空间不足拷贝会奔溃的情况
2、修复文件不存在会崩溃的情况
3、去掉多余到 43～45 的原地址获取，因为在 AndroidQDBUtils.getUri(assetId,type, isOrigin) 已获取